### PR TITLE
Add 'thedyrt' prefix to usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Optionally sets the checkout directory to a specified path.
 ```yml
 steps:
   - plugins:
-      skip-checkout#v0.1.1: ~
+      thedyrt/skip-checkout#v0.1.1: ~
 ```
 
 ```yml
 steps:
   - plugins:
-      skip-checkout#v0.1.1:
+      thedyrt/skip-checkout#v0.1.1:
         cd: /mnt/data
 ```
 


### PR DESCRIPTION
Hey, this plugin is great! I think the usage examples might not work, because they don't have your GitHub org/username in there, so this PR fixes those up.

I'll file a bug to get the plugin-linter fixed so it picks this up too.