### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Optionally sets the checkout directory to a specified path.
 ```yml
 steps:
   - plugins:
-      thedyrt/skip-checkout#v0.1.1: ~
+      - thedyrt/skip-checkout#v0.1.1: ~
 ```
 
 ```yml
 steps:
   - plugins:
-      thedyrt/skip-checkout#v0.1.1:
-        cd: /mnt/data
+      - thedyrt/skip-checkout#v0.1.1:
+          cd: /mnt/data
 ```
 
 ## Tests


### PR DESCRIPTION
Hi again @reidab 😊

(This is the same as https://github.com/thedyrt/git-commit-buildkite-plugin/pull/3, but I'm not sure which one you'll get to first, so here's all the info again!)

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.