### PR TITLE
Delete any old artifacts

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -2,5 +2,6 @@
 
 set -euo pipefail
 
-echo "--- Removing any files from previous builds"
+echo "--- Skipping checkout"
+echo "Removing any old artifacts"
 rm -rf ./*

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 echo "--- Removing any files from previous builds"
-rm -rf *
+rm -rf ./*

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -2,4 +2,5 @@
 
 set -euo pipefail
 
-echo "--- Skipping checkout"
+echo "--- Removing any files from previous builds"
+rm -rf *

--- a/tests/checkout.bats
+++ b/tests/checkout.bats
@@ -23,6 +23,17 @@ post_checkout_hook="$PWD/hooks/post-checkout"
   assert_output --partial "Skipping checkout"
 }
 
+@test "Removes old artifacts {
+  export BUILDKITE_BUILD_CHECKOUT_PATH=$tmp_dir
+  cd "$BUILDKITE_BUILD_CHECKOUT_PATH"
+  touch some_old_artifact
+
+  run "$checkout_hook"
+
+  assert_success
+  refute [ -f some_old_artifact ]
+}
+
 @test "Updates checkout directory when 'cd' is given" {
   export BUILDKITE_BUILD_CHECKOUT_PATH=$tmp_dir
   export BUILDKITE_PLUGIN_SKIP_CHECKOUT_CD="/var"


### PR DESCRIPTION
I had a problem using artifacts with this plugin, I reached out to buildkite and their response included:

> I’d suggest that the problem here is that the skip checkout plugin doesn’t clean out the build directory - I guess it’s presuming that nothing ever will be written to the build directory! A patch which adds an rm -rf to the “checkout” hook should fix your issue, and I suspect would be accepted to the plugin itself!

Before buildkite yields to the checkout hook, it cds to the workers build directory, e.g. `cd /buildkite/builds/<worker-id>/<myorg>/<pipeline>`. So if any artifacts were written in a previous build, they would still exist here. 

This PR deletes everything in the build directory so that you don't run into problems with random old artifacts showing up in new builds.

I don't think deleting will cause an issue with the cd option, because it seems like that happens after the checkout hook, in the post-checkout hook.